### PR TITLE
docs: fix outdated README structure and update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,173 +1,203 @@
+# Incredible Portfolio (PHP)
 
-# Incredible Portfolio (PHP) 
-
-A clean, modern **vanilla PHP** portfolio with a tiny router, shared layout, responsive UI, and a secure contact form (CSRF + validation). Zero external PHP dependencies - deploy anywhere PHP runs.
+A clean, modern **vanilla PHP** portfolio with a tiny router, shared layout, responsive UI, and a secure contact form (CSRF + validation). Zero external PHP dependencies – deploy anywhere PHP runs.
 
 ![PHP >= 8.0](https://img.shields.io/badge/PHP-%3E%3D%208.0-777BB4.svg?logo=php&logoColor=white)
 ![Framework: None](https://img.shields.io/badge/Framework-None-0F172A)
 ![License: MIT](https://img.shields.io/badge/License-MIT-10B981)
 
-
 ---
 
 ## Features
--  **Lightweight:** plain PHP, no frameworks
--  **Simple routing:** `public/index.php?page=home|projects|about|contact`
--  **Reusable layout:** shared header/footer partials
--  **Easy content:** edit one `app/data/projects.php` array
--  **Secure contact form:** CSRF token + validation
--  **Reliable logging:** messages saved to `storage/messages.csv` (and `mail()` attempted if available)
--  **Modern UI:** responsive grid, cards, accessible colors
+
+- **Lightweight:** plain PHP, no frameworks  
+- **Simple routing:** `index.php?page=home|projects|about|contact`  
+- **Reusable layout:** shared `header.php` / `footer.php` partials  
+- **Easy content:** edit one `data/projects.php` array  
+- **Secure contact form:** CSRF token + validation  
+- **Reliable logging:** messages saved to `storage/messages.csv` (and `mail()` attempted if available)  
+- **Modern UI:** responsive grid, cards, accessible colors  
 
 ---
 
 ## Folder Structure
-```
-incredible-portfolio/
-|-- index.php           # Router (whitelists pages)
-|-- config.php          # Site name, tagline, owner, contact_email
-|-- functions.php       # Helpers: config(), e(), CSRF, mail, save_message
-|-- header.php          # Shared header/layout (top)
-|-- footer.php          # Shared footer/layout (bottom)
-|-- assets/             # Frontend assets
-|   |-- css/
-|   |   `-- style.css
-|   |-- js/
-|   |   `-- main.js
-|   `-- img/
-|       `-- ... your images ...
-|-- pages/              # Individual pages rendered by index.php
-|   |-- home.php
-|   |-- projects.php
-|   |-- about.php
-|   `-- contact.php
-|-- data/
-|   `-- projects.php    # Your projects array
-|-- storage/            # Contact form CSV (auto-created)
-|   `-- messages.csv
-|-- LICENSE
-`-- README.md
-```
+
+    incredible-portfolio/
+    |-- index.php           # Router (whitelists pages)
+    |-- config.php          # Site name, tagline, owner, contact_email
+    |-- functions.php       # Helpers: config(), e(), CSRF, mail, save_message
+    |-- header.php          # Shared header/layout (top)
+    |-- footer.php          # Shared footer/layout (bottom)
+    |-- assets/             # Frontend assets
+    |   |-- css/
+    |   |   `-- style.css
+    |   |-- js/
+    |   |   `-- main.js
+    |   `-- img/
+    |       `-- ... your images ...
+    |-- pages/              # Individual pages rendered by index.php
+    |   |-- home.php
+    |   |-- projects.php
+    |   |-- about.php
+    |   `-- contact.php
+    |-- data/
+    |   `-- projects.php    # Your projects array
+    |-- storage/            # Contact form CSV (auto-created)
+    |   `-- messages.csv
+    |-- LICENSE
+    `-- README.md
+
 ---
 
 ## Quick Start
 
 ### 1) Run locally
-```bash
-# from the project root
-php -S localhost:8000
-```
-Open **http://localhost:8000**
+
+From the project root:
+
+    php -S localhost:8000
+
+Then open:
+
+    http://localhost:8000
+
+---
 
 ### 2) Configure
+
 Edit `config.php`:
 
-```php
-return [
-    'site_name' => 'Incredible Portfolio',
-    'tagline'   => 'Developer - Builder - Learner',
-    'owner'     => 'Your Name',
-    'contact_email' => 'you@example.com', // used for mail(); CSV logging is always on
-];
-```
-Update projects in **`app/data/projects.php`** (title, description, tech, links, `featured`).
+    return [
+        'site_name'      => 'Incredible Portfolio',
+        'tagline'        => 'Developer - Builder - Learner',
+        'owner'          => 'Your Name',
+        'contact_email'  => 'you@example.com', // used for mail(); CSV logging is always on
+    ];
 
-> **Permissions:** Ensure the server can write to `/storage` so `messages.csv` can be created (e.g., Linux: `chmod 755 storage` or `775` depending on your user/group).
+Update projects in `data/projects.php` (title, description, tech, links, `featured`).
+
+> **Permissions:** Ensure the server can write to `/storage` so `messages.csv` can be created (for example on Linux: `chmod 755 storage` or `775` depending on your user/group).
+
+---
 
 ### 3) Add / remove pages
-- Create a new file in `app/pages/` (e.g., `services.php`).
-- Whitelist it in **`public/index.php`**:
-  ```php
-  $allowed = ['home','projects','about','contact','services'];
-  ```
-- Link it in the header nav if needed (`app/partials/header.php`).
+
+- Create a new file in `pages/` (for example: `pages/services.php`).  
+- Whitelist it in `index.php`:
+
+      $allowed = ['home', 'projects', 'about', 'contact', 'services'];
+
+- Link it in the header nav if needed (`header.php`).
 
 ---
 
 ## Contact Form
 
-- Form lives in **`app/pages/contact.php`**
-- **Security:** CSRF token + server-side validation
-- **Delivery:** Always logs to `storage/messages.csv` and **attempts** `mail()` to `contact_email`
-- **No SMTP by default:** If your host doesn't allow `mail()`, you still have the CSV log.  
-  For SMTP, integrate a mailer (e.g., PHPMailer) in `app/lib/functions.php` (optional future enhancement).
+- Form lives in `pages/contact.php`.  
+- **Security:** CSRF token + server-side validation.  
+- **Delivery:** Always logs to `storage/messages.csv` and attempts `mail()` to `contact_email`.  
+- **No SMTP by default:** If your host does not allow `mail()`, you still have the CSV log.  
+  For SMTP, integrate a mailer (for example PHPMailer) inside `functions.php` as a future enhancement.
 
 ---
 
 ## Deployment
 
 ### Shared Hosting (cPanel / Plesk)
-1. Create a domain/subdomain (e.g., `portfolio.example.com`).
-2. **Set document root to the `public/` folder**.
-3. Upload all project files, keeping the structure intact.
+
+1. Create a domain or subdomain (for example `portfolio.example.com`).  
+2. Set the document root to the project directory (where `index.php` lives).  
+3. Upload all project files, keeping the structure intact.  
 4. Ensure PHP **8.0+** is selected in your hosting panel.
 
 ### Apache (VPS)
-Set the **DocumentRoot** to the `public/` directory:
-```apache
-<VirtualHost *:80>
-  ServerName example.com
-  DocumentRoot /var/www/incredible-portfolio-php/public
 
-  <Directory /var/www/incredible-portfolio-php/public>
-    AllowOverride All
-    Require all granted
-  </Directory>
+Example virtual host:
 
-  # PHP handler (varies by setup)
-  # ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/var/www/incredible-portfolio-php/public/$1
-</VirtualHost>
-```
+    <VirtualHost *:80>
+      ServerName example.com
+      DocumentRoot /var/www/incredible-portfolio
+
+      <Directory /var/www/incredible-portfolio>
+        AllowOverride All
+        Require all granted
+      </Directory>
+
+      # PHP handler (varies by setup)
+      # ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/var/www/incredible-portfolio/$1
+    </VirtualHost>
 
 ### Nginx (VPS)
-```nginx
-server {
-  listen 80;
-  server_name example.com;
-  root /var/www/incredible-portfolio-php/public;
-  index index.php;
 
-  location / {
-    try_files $uri $uri/ /index.php?$query_string;
-  }
+Example server block:
 
-  location ~ \.php$ {
-    include snippets/fastcgi-php.conf;
-    fastcgi_pass unix:/run/php/php8.2-fpm.sock; # adjust version/socket
-  }
-}
-```
+    server {
+      listen 80;
+      server_name example.com;
+      root /var/www/incredible-portfolio;
+      index index.php;
+
+      location / {
+        try_files $uri $uri/ /index.php?$query_string;
+      }
+
+      location ~ \.php$ {
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass unix:/run/php/php8.2-fpm.sock;  # adjust PHP version/socket
+      }
+    }
 
 ---
 
 ## Customize the Design
 
-* Styles: `assets/css/style.css` (CSS variables at the top)
-* Small JS: `assets/js/main.js` (mobile nav toggle)
-* Images: `assets/img/` (replace the placeholder SVG with your project shots)
+- Styles: `assets/css/style.css` (CSS variables and base styles at the top)  
+- JavaScript: `assets/js/main.js` (mobile navigation, small enhancements)  
+- Images: replace or add files under `assets/img/`  
+- Layout: adjust `header.php` and `footer.php` for branding, navigation, and structure  
+
+The code is intentionally minimal so you can easily adapt it to your own style.
 
 ---
 
 ## Troubleshooting
-- **Blank page / 404** → Ensure your web root points to `public/` (not the repo root).
-- **No emails arriving** → Hosts often block `mail()`. CSV logging still works. Consider SMTP.
-- **`messages.csv` not created** → Make sure `/storage` is writable by the web server user.
-- **Assets not loading** → Check relative path `public/assets/...` and case-sensitive filenames.
+
+- **Blank page / 404**  
+  Make sure the server is serving the project directory and `index.php` is used as the entry point.
+
+- **Emails not arriving**  
+  Many shared hosts restrict `mail()`. Use the CSV log in `storage/messages.csv` as a fallback,  
+  or integrate SMTP with a library like PHPMailer.
+
+- **`messages.csv` not created**  
+  Check write permissions on the `storage` directory.
+
+- **Assets not loading**  
+  Confirm the paths under `assets/` and ensure filenames and case match exactly.
 
 ---
 
-## Roadmap (Optional Enhancements)
-- SMTP transport (PHPMailer/SwiftMailer)
-- RSS/Blog page
-- Project filter/search (client-side)
-- Sitemap.xml + basic SEO tags
+## Roadmap
+
+Ideas for future enhancements:
+
+- SMTP transport via PHPMailer or another mailer  
+- Client-side project search and filtering  
+- Simple blog or notes section  
+- Basic SEO meta tags and Open Graph data  
+- Automatic sitemap.xml generation  
+- Optional dark mode theme  
 
 ---
 
 ## License
-MIT - see [LICENSE](LICENSE).
+
+This project is licensed under the MIT License.  
+See the `LICENSE` file for full details.
 
 ---
 
-### Credits
-Made with love using vanilla PHP. Customize freely and ship it!
+## Credits
+
+Built with vanilla PHP, HTML, CSS, and a little JavaScript.  
+Simple to read, simple to deploy, and easy to adapt to your own developer portfolio.


### PR DESCRIPTION
### Summary
This PR updates the README to reflect the current project structure and corrects outdated instructions.  
The previous README referenced `public/` and `app/` directories that no longer exist, which caused confusion when running or deploying the project.

### Changes Included
- Updated folder structure to match the real repository layout.
- Updated Quick Start instructions to run PHP’s built-in server from the project root.
- Updated instructions for adding new pages to use the `pages/` directory.
- Clarified contact form behavior, logging, and required permissions.
- Cleaned up deployment examples for Apache and Nginx.
- Modernized wording and ensured consistency across sections.

### Why This Fix Was Needed
The original README did not match the actual codebase, leading to incorrect setup steps and misunderstanding of how routing and pages work.  
This PR resolves Issue #5 and ensures new users can follow accurate instructions.

### Related Issue
Closes #5 