### PR TITLE
Fix 404 routing to show proper not-found page

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,11 +1,21 @@
 <?php
 require __DIR__ . '/functions.php';
+
 $page = $_GET['page'] ?? 'home';
-$allowed = ['home','projects','about','contact'];
+
+// Allow explicit 404 route too
+$allowed = ['home', 'projects', 'about', 'contact', '404'];
+
 if (!in_array($page, $allowed, true)) {
   http_response_code(404);
-  $page = 'home';
+  $page = '404';
 }
+
+// If someone directly visits ?page=404, ensure status is correct
+if ($page === '404') {
+  http_response_code(404);
+}
+
 require __DIR__ . '/header.php';
 require __DIR__ . '/pages/' . $page . '.php';
 require __DIR__ . '/footer.php';

--- a/pages/404.php
+++ b/pages/404.php
@@ -1,0 +1,23 @@
+<section class="section">
+  <header class="section-header">
+    <div>
+      <h1 class="section-title">Page not found</h1>
+      <p class="lead">
+        The page you requested doesn’t exist (or may have been moved).
+      </p>
+    </div>
+  </header>
+
+  <?php $requested = trim((string)($_GET['page'] ?? '')); ?>
+  <?php if ($requested !== '' && $requested !== '404'): ?>
+    <p class="lead">
+      Requested: <strong><?php echo e($requested); ?></strong>
+    </p>
+  <?php endif; ?>
+
+  <div class="cta" style="margin-top: 1rem;">
+    <a class="btn primary" href="./?page=home">Go to Home</a>
+    <a class="btn" href="./?page=projects">View Projects</a>
+    <a class="btn" href="./?page=contact">Contact</a>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
This PR fixes routing behavior so invalid `?page=` values render a dedicated 404 page instead of showing the Home page with a 404 status.

## Changes
- Updated `index.php` to route invalid pages to `pages/404.php`
- Added `pages/404.php` (simple, consistent UI + navigation links)
- Ensures HTTP status is `404` both for invalid pages and explicit `?page=404`

## Testing
- Visit a valid page: `/?page=home` → renders Home with status 200
- Visit invalid page: `/?page=does-not-exist` → renders 404 page with status 404
- Visit explicit 404: `/?page=404` → renders 404 page with status 404