### PR TITLE
Fix storage directory exposure by correcting .htaccess rules

### DIFF
--- a/storage/.htaccess
+++ b/storage/.htaccess
@@ -1,4 +1,5 @@
-location ^~ /storage/ {
-  deny all;
-  return 404;
-}
+# Block all direct access to storage directory (Apache)
+Require all denied
+
+# Extra hardening
+Options -Indexes


### PR DESCRIPTION
## Summary
Fixes a critical security issue where the `storage/.htaccess` file contained
Nginx syntax, which is ignored by Apache servers.

As a result, sensitive files like `messages.csv` could be publicly accessible.

## Changes
- Replaced invalid Nginx config with valid Apache `.htaccess` rules
- Disabled directory listing for extra safety
- (Optional) Clarified Apache vs Nginx setup in README

Fixes #14 