### PR TITLE
Harden contact mail headers to prevent header injection

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -52,10 +52,45 @@ function save_message(array $payload): void {
 
 function attempt_mail(array $payload): bool {
   $to = config('contact_email');
-  $subject = '[Portfolio] ' . ($payload['subject'] ?? 'New message');
-  $headers = 'From: ' . ($payload['email'] ?? 'no-reply@example.com') . "\r\n";
-  $headers .= 'Reply-To: ' . ($payload['email'] ?? 'no-reply@example.com') . "\r\n";
+
+  // Defend against header injection: reject CRLF in any header-bound input.
+  $rawEmail = trim((string)($payload['email'] ?? ''));
+  if ($rawEmail !== '' && (strpos($rawEmail, "\r") !== false || strpos($rawEmail, "\n") !== false)) {
+    return false;
+  }
+
+  // Validate the reply-to email (defense in depth, even if caller validates).
+  $replyTo = '';
+  if ($rawEmail !== '' && filter_var($rawEmail, FILTER_VALIDATE_EMAIL)) {
+    $replyTo = $rawEmail;
+  }
+
+  // Subject is also header-adjacent; strip CRLF and keep it short.
+  $rawSubject = (string)($payload['subject'] ?? 'New message');
+  $safeSubject = trim(str_replace(["\r", "\n"], '', $rawSubject));
+  if ($safeSubject === '') {
+    $safeSubject = 'New message';
+  }
+  if (strlen($safeSubject) > 160) {
+    $safeSubject = substr($safeSubject, 0, 160);
+  }
+  $subject = '[Portfolio] ' . $safeSubject;
+
+  // Use a fixed From address; only set Reply-To to the visitor's address (when valid).
+  $from = 'no-reply@example.com';
+  $headers = 'From: Portfolio <' . $from . ">\r\n";
+  if ($replyTo !== '') {
+    $headers .= 'Reply-To: ' . $replyTo . "\r\n";
+  }
   $headers .= 'Content-Type: text/plain; charset=UTF-8' . "\r\n";
-  $body = "Name: {$payload['name']}\nEmail: {$payload['email']}\nSubject: {$payload['subject']}\n\n{$payload['message']}\n";
+
+  $name = (string)($payload['name'] ?? '');
+  $message = (string)($payload['message'] ?? '');
+
+  $body = "Name: {$name}\n";
+  $body .= "Email: {$rawEmail}\n";
+  $body .= "Subject: {$safeSubject}\n\n";
+  $body .= $message . "\n";
+
   return function_exists('mail') ? @mail($to, $subject, $body, $headers) : false;
 }


### PR DESCRIPTION
## Summary
This hardens the contact form mailer against email header injection.

Previously, the user-provided email was inserted directly into `From:` and `Reply-To:` headers, which can be abused with CRLF characters on some mail setups.

### Fixes #15 

## Changes
- Reject CRLF characters in header-bound fields (email/subject)
- Validate email inside `attempt_mail()` (defense in depth)
- Use a fixed `From:` address and set `Reply-To:` only when valid
- Strip CRLF from subject and cap subject length

## Testing
- Normal valid email sends successfully and sets `Reply-To`
- Invalid email does not get used in headers
- Emails containing `\r` or `\n` are rejected (prevents header injection)